### PR TITLE
feat: support container_definitions variable for direct JSON input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,9 +163,11 @@ resource "aws_lb_target_group" "task" {
 # ECS Task/Service
 #####
 locals {
-  container_definitions = var.container_definition_file_path == "" ? "" : templatefile(var.container_definition_file_path, {
-    log_group = "${aws_cloudwatch_log_group.main.name}"
-  })
+  container_definitions = var.container_definitions != null ? var.container_definitions : (
+    var.container_definition_file_path == "" ? "" : templatefile(var.container_definition_file_path, {
+      log_group = "${aws_cloudwatch_log_group.main.name}"
+    })
+  )
 
   task_environment = [
     for k, v in var.task_container_environment : {


### PR DESCRIPTION
Allow users to pass pre-rendered container definitions JSON directly via the `container_definitions` variable. This enables:

- Custom templatefile variables beyond just log_group
- Dynamic image tags from data sources (e.g., current running task)
- More flexible container definition management

The existing `container_definition_file_path` behavior is preserved as a fallback when `container_definitions` is null (default).

Backward compatible: existing configurations using `container_definition_file_path` will continue to work unchanged.