### PR TITLE
feat: add task_execution_role_arn and task_role_arn variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="8.1.0"></a>
+## [8.1.0] - 2026-03-12
+
+- feat: add `task_execution_role_arn` and `task_role_arn` variables to allow overriding auto-created IAM roles
+
+
 <a name="8.0.4"></a>
 ## [8.0.4] - 2023-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,7 +350,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.4...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.7...HEAD
+[8.0.7]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.4...8.0.7
 [8.0.4]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.3...8.0.4
 [8.0.3]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.2...8.0.3
 [8.0.2]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.1...8.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to this project will be documented in this file.
 
 
 
-<a name="8.1.0"></a>
-## [8.1.0] - 2026-03-12
+<a name="8.0.7"></a>
+## [8.0.7] - 2026-03-12
 
 - feat: add `task_execution_role_arn` and `task_role_arn` variables to allow overriding auto-created IAM roles
 

--- a/main.tf
+++ b/main.tf
@@ -193,12 +193,12 @@ locals {
 
 resource "aws_ecs_task_definition" "task" {
   family                   = var.name_prefix
-  execution_role_arn       = aws_iam_role.execution.arn
+  execution_role_arn       = var.task_execution_role_arn != "" ? var.task_execution_role_arn : aws_iam_role.execution.arn
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.task_definition_cpu
   memory                   = var.task_definition_memory
-  task_role_arn            = aws_iam_role.task.arn
+  task_role_arn            = var.task_role_arn != "" ? var.task_role_arn : aws_iam_role.task.arn
 
   dynamic "ephemeral_storage" {
     for_each = var.task_definition_ephemeral_storage == 0 ? [] : [var.task_definition_ephemeral_storage]

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,12 +15,12 @@ output "target_group_name" {
 
 output "task_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the ECS service role."
-  value       = aws_iam_role.task.arn
+  value       = var.task_role_arn != "" ? var.task_role_arn : aws_iam_role.task.arn
 }
 
 output "task_role_name" {
   description = "The name of the Fargate task service role."
-  value       = aws_iam_role.task.name
+  value       = var.task_role_arn != "" ? null : aws_iam_role.task.name
 }
 
 output "service_sg_ids" {
@@ -40,12 +40,12 @@ output "log_group_name" {
 
 output "execution_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the ECS execution role."
-  value       = aws_iam_role.execution.arn
+  value       = var.task_execution_role_arn != "" ? var.task_execution_role_arn : aws_iam_role.execution.arn
 }
 
 output "execution_role_name" {
   description = "The name of the ECS execution role."
-  value       = aws_iam_role.execution.name
+  value       = var.task_execution_role_arn != "" ? null : aws_iam_role.execution.name
 }
 
 output "task_definition_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "task_role_arn" {
 
 output "task_role_name" {
   description = "The name of the Fargate task service role."
-  value       = var.task_role_arn != "" ? null : aws_iam_role.task.name
+  value       = var.task_role_arn != "" ? element(split("/", var.task_role_arn), length(split("/", var.task_role_arn)) - 1) : aws_iam_role.task.name
 }
 
 output "service_sg_ids" {
@@ -45,7 +45,7 @@ output "execution_role_arn" {
 
 output "execution_role_name" {
   description = "The name of the ECS execution role."
-  value       = var.task_execution_role_arn != "" ? null : aws_iam_role.execution.name
+  value       = var.task_execution_role_arn != "" ? element(split("/", var.task_execution_role_arn), length(split("/", var.task_execution_role_arn)) - 1) : aws_iam_role.execution.name
 }
 
 output "task_definition_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "task_role_arn" {
 
 output "task_role_name" {
   description = "The name of the Fargate task service role."
-  value       = var.task_role_arn != "" ? element(split("/", var.task_role_arn), length(split("/", var.task_role_arn)) - 1) : aws_iam_role.task.name
+  value       = var.task_role_arn != "" ? split("/", var.task_role_arn)[length(split("/", var.task_role_arn)) - 1] : aws_iam_role.task.name
 }
 
 output "service_sg_ids" {
@@ -45,7 +45,7 @@ output "execution_role_arn" {
 
 output "execution_role_name" {
   description = "The name of the ECS execution role."
-  value       = var.task_execution_role_arn != "" ? element(split("/", var.task_execution_role_arn), length(split("/", var.task_execution_role_arn)) - 1) : aws_iam_role.execution.name
+  value       = var.task_execution_role_arn != "" ? split("/", var.task_execution_role_arn)[length(split("/", var.task_execution_role_arn)) - 1] : aws_iam_role.execution.name
 }
 
 output "task_definition_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,18 @@ variable "task_role_policy_document" {
   type        = string
 }
 
+variable "task_role_arn" {
+  description = "ARN of an existing IAM role to use as the task role. If not provided, a new role will be created."
+  type        = string
+  default     = ""
+}
+
+variable "task_execution_role_arn" {
+  description = "ARN of an existing IAM role to use as the task execution role. If not provided, a new role will be created."
+  type        = string
+  default     = ""
+}
+
 variable "task_container_secrets" {
   description = "The secrets variables to pass to a container."
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -127,13 +127,13 @@ variable "task_role_policy_document" {
 }
 
 variable "task_role_arn" {
-  description = "ARN of an existing IAM role to use as the task role. If not provided, a new role will be created."
+  description = "ARN of an existing IAM role to use as the task role. If not provided, a new role will be created. Note: when set, task_role_policy_document is NOT applied to the provided role — ensure the role already has the required permissions."
   type        = string
   default     = ""
 }
 
 variable "task_execution_role_arn" {
-  description = "ARN of an existing IAM role to use as the task execution role. If not provided, a new role will be created."
+  description = "ARN of an existing IAM role to use as the task execution role. If not provided, a new role will be created. Note: when set, task_role_policy_document is NOT applied to the provided role — ensure the role already has the required permissions (e.g. ECR pull, Secrets Manager access)."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary

- `task_execution_role_arn`: ARN of an existing IAM role to use as the task execution role. If not provided, a new role is created (existing behavior unchanged).
- `task_role_arn`: ARN of an existing IAM role to use as the task role. If not provided, a new role is created (existing behavior unchanged).

## Motivation

In cross-account ECR scenarios, the auto-created task execution role (`{name_prefix}-task-execution-role`) is not listed in the ECR repository policy of another account. By allowing callers to pass an existing role ARN (e.g. the `system` role which already has cross-account ECR access), this issue can be resolved without modifying the ECR policy.

## Usage

```hcl
module "ecs_fargate" {
  source = "github.com/ab180/terraform-aws-ecs-fargate?ref=8.0.7"

  # ... other variables ...

  task_execution_role_arn = "arn:aws:iam::123456789012:role/system"
  task_role_arn           = "arn:aws:iam::123456789012:role/system"
}
```

## ⚠️ Important Note

When `task_execution_role_arn` or `task_role_arn` is set, **`task_role_policy_document` is NOT applied to the provided role**. The module only attaches `task_role_policy_document` to the roles it creates internally. If you use custom role ARNs, ensure those roles already have all required permissions (ECR pull, Secrets Manager access, etc.).

## Backward Compatibility

Both variables default to `""` so existing callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)