### PR TITLE
fix: restore log_group_name variable accidentally removed in 8.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="8.0.8"></a>
+## [8.0.8] - 2026-03-12
+
+- fix: restore `log_group_name` variable accidentally removed in 8.0.6
+
+
 <a name="8.0.7"></a>
 ## [8.0.7] - 2026-03-12
 
@@ -350,7 +356,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.7...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.8...HEAD
+[8.0.8]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.7...8.0.8
 [8.0.7]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.4...8.0.7
 [8.0.4]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.3...8.0.4
 [8.0.3]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/8.0.2...8.0.3

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # Cloudwatch
 #####
 resource "aws_cloudwatch_log_group" "main" {
-  name = var.name_prefix
+  name = coalesce(var.log_group_name, var.name_prefix)
 
   retention_in_days = var.log_retention_in_days
   kms_key_id        = var.logs_kms_key

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "name_prefix" {
   type        = string
 }
 
+variable "log_group_name" {
+  description = "A log group name. If not provided, name_prefix is used."
+  type        = string
+  default     = null
+}
+
 variable "sg_name_prefix" {
   description = "A prefix used for Security group name."
   type        = string


### PR DESCRIPTION
## Summary

PR #4 (8.0.6)에서 `container_definitions` 변수를 추가하는 과정에 `log_group_name` 변수가 실수로 제거되었습니다. 이를 복원합니다.

## Changes

- `variables.tf`: `log_group_name` 변수 복원 (`default = null`)
- `main.tf`: `aws_cloudwatch_log_group.main`의 name을 `coalesce(var.log_group_name, var.name_prefix)`로 복원

## Behavior

- `log_group_name` 미지정 시: 기존처럼 `name_prefix` 사용 (backward compatible)
- `log_group_name` 지정 시: 지정한 이름 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)